### PR TITLE
fix: move large configuration files used by tunasync worker to s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is the infrasture project of Open TUNA on AWS orchestrated by [AWS CDK][aws
 - Common stack
   - SNS notification topic
 - Open TUNA stack
+  - S3 asset bucket
   - Tunasync Manager stack
     - auto scaling group for [tunasync][tunasync] manager
     - intranet application load balancer for manager's API
@@ -18,13 +19,14 @@ This is the infrasture project of Open TUNA on AWS orchestrated by [AWS CDK][aws
     - install necessary third party tools for mirroring tasks
     - use systemctl as daemon to start tunasync worker
     - send custom CloudWatch metrics of tunasync process info
+    - publish large configuration files to s3 asset bucket
   - Content Server stack
     - build custom nginx container
     - use Fargate service to serve mirror contents
     - internet facing appplication load balancer
   - Web Portal stack
     - use tuna/mirror-web
-    - route tunasync.json to tunasync worker
+    - route tunasync.json to tunasync manager
 
 ## Prerequisites
 - VPC with both public and private subnets crossing two AZs at least and NAT gateway. You can [deploy the network stack](#deploy-network-stackoptional) if you don't have a VPC sastfied the requirements.

--- a/lib/opentuna-stack.ts
+++ b/lib/opentuna-stack.ts
@@ -3,6 +3,7 @@ import ec2 = require('@aws-cdk/aws-ec2');
 import sns = require('@aws-cdk/aws-sns');
 import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2');
 import ecs = require('@aws-cdk/aws-ecs');
+import s3 = require('@aws-cdk/aws-s3');
 import { TunaManagerStack } from './tuna-manager';
 import { TunaWorkerStack } from './tuna-worker';
 import { ContentServerStack } from './content-server';
@@ -21,6 +22,10 @@ export class OpentunaStack extends cdk.Stack {
 
     const vpc = ec2.Vpc.fromLookup(this, `VPC-${props.vpcId}`, {
       vpcId: props.vpcId,
+    });
+
+    const assetBucket = new s3.Bucket(this, `OpenTunaAssets`, {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
     const tunaManagerSG = new ec2.SecurityGroup(this, "TunaManagerSG", {
@@ -67,6 +72,7 @@ export class OpentunaStack extends cdk.Stack {
       managerUrl: `http://${tunaManagerStack.managerALB.loadBalancerDnsName}:${tunaManagerStack.managerPort}`,
       timeout: cdk.Duration.minutes(10),
       tunaWorkerSG,
+      assetBucket,
     });
 
     tunaManagerALBSG.connections.allowFrom(tunaWorkerSG, ec2.Port.tcp(tunaManagerStack.managerPort), 'Access from tuna worker');

--- a/lib/tuna-worker-cloudwatch-agent.txt
+++ b/lib/tuna-worker-cloudwatch-agent.txt
@@ -1,0 +1,56 @@
+{
+"metrics": {
+        "namespace": "{{&namespace}}",
+        "append_dimensions": {
+        "ImageId": "${aws:ImageId}",
+        "InstanceId": "${aws:InstanceId}",
+        "InstanceType": "${aws:InstanceType}",
+        "{{&dimensionName}}": "${aws:AutoScalingGroupName}"
+        },
+        "aggregation_dimensions" : [["{{&dimensionName}}"]],
+        "metrics_collected": {
+        "procstat": [
+                {
+                "exe": "tunasync",
+                "measurement": [
+                        "pid_count"
+                ]
+                }
+        ]
+        }
+},
+"logs": {
+        "logs_collected": {
+        "files": {
+                "collect_list": [
+                {
+                        "file_path": "/var/log/tunasync.log",
+                        "log_group_name": "{{&logPrefix}}/worker",
+                        "log_stream_name": "{instance_id}_{hostname}",
+                        "timestamp_format": "%H: %M: %S%y%b%-d",
+                        "timezone": "UTC"
+                }
+                {{#mirrors}}
+                ,
+                {
+                        "file_path": "{{&repoRoot}}/log/{{&name}}/{{&name}}_**",
+                        "log_group_name": "{{&logPrefix}}/mirrors/{{&name}}",
+                        "log_stream_name": "{instance_id}_{hostname}",
+                        {{#timeFormat}}
+                        "timestamp_format": "{{&timeFormat}}",
+                        {{/timeFormat}}
+                        {{^timeFormat}}
+                        "timestamp_format": "%H: %M: %S%y%b%-d",
+                        {{/timeFormat}}
+                        {{#logStartPattern}}
+                        "multi_line_start_pattern": "{{&logStartPattern}}",
+                        {{/logStartPattern}}
+                        "timezone": "UTC"
+                }
+                {{/mirrors}}
+                ]
+        }
+        },
+        "log_stream_name": "open-mirror-default-stream-name"
+}
+}

--- a/lib/tuna-worker-tunasync.conf
+++ b/lib/tuna-worker-tunasync.conf
@@ -1,0 +1,52 @@
+[global]
+name = "tunasync-worker"
+{{=<% %>=}}
+log_dir = "<%&repoRoot%>/log/{{.Name}}"
+<%={{ }}=%>
+mirror_dir = "{{&repoRoot}}/data/"
+concurrent = 10
+interval = 1
+retry = 5
+
+[manager]
+api_base = "++MANAGERURL++"
+token = ""
+ca_cert = ""
+
+[cgroup]
+enable = false
+
+[server]
+hostname = "++HOSTNAME++"
+listen_addr = "0.0.0.0"
+listen_port = {{port}}
+ssl_cert = ""
+ssl_key = ""
+
+{{#mirrors}}
+[[mirrors]]
+name = "{{&name}}"
+{{#interval}}
+interval = {{interval}}
+{{/interval}}
+{{#retry}}
+retry = {{retry}}
+{{/retry}}
+provider = "{{&provider}}"
+upstream = "{{&upstream}}"
+{{#stage1_profile}}
+stage1_profile = "{{&stage1_profile}}"
+{{/stage1_profile}}
+{{#command}}
+command = "{{&command}}"
+{{/command}}
+{{#envs.length}}
+        [mirrors.env]
+        {{#envs}}
+        {{&.}}
+        {{/envs}}
+{{/envs.length}}
+{{#rsync_options.length}}
+rsync_options = [ {{&rsync_options}} ]
+{{/rsync_options.length}}
+{{/mirrors}}

--- a/lib/tuna-worker-user-data.txt
+++ b/lib/tuna-worker-user-data.txt
@@ -15,6 +15,7 @@ packages:
  - amazon-efs-utils
  - python3-pip
  - git
+ - awscli
 
 # run commands
 runcmd:
@@ -29,7 +30,7 @@ runcmd:
  - (test -f ${tunafile} && tar -xf ${tunafile} -C /usr/local/bin/) || (wget -c https://github.com/tuna/tunasync/releases/download/${tunaversion}/tunasync-linux-bin.tar.bz2 -O - | tar xjf -  -C /usr/local/bin/)
  - export PIP_DEFAULT_TIMEOUT=20; pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple 'bandersnatch<4.0' || pip3 install -i https://pypi.douban.com/simple 'bandersnatch<4.0'
  - tunascript_bin="${efs_mount_point_1}/tunasync/install/tunasync-scripts.tar.gz"
- - tunascriptpath=/tunasync-scripts
+ - tunascriptpath={{&tunaScriptPath}}
  - mkdir -p ${tunascriptpath}
  - (test -f ${tunascript_bin} && tar -xf ${tunascript_bin} -C ${tunascriptpath}) || (git clone https://github.com/tuna/tunasync-scripts.git ${tunascriptpath})
  - rpm -i https://{{&s3RegionEndpoint}}/amazoncloudwatch-agent-{{&region}}/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
@@ -44,65 +45,15 @@ Content-Disposition: attachment; filename="userdata.txt"
 
 #!/bin/bash -xe
 HOSTNAME=`hostname`
-REPO_ROOT={{&repoRoot}}
-TUNASCRIPT_PATH=/tunasync-scripts
+MANAGERURL="{{&managerUrl}}"
 mkdir -p /etc/tunasync/
 
+export AWS_DEFAULT_REGION={{&region}}
+
 # create tunasync work config
-cat > /etc/tunasync/worker.conf << EOF
-[global]
-name = "tunasync-worker"
-{{=<% %>=}}
-log_dir = "${REPO_ROOT}/log/{{.Name}}"
-<%={{ }}=%>
-mirror_dir = "${REPO_ROOT}/data/"
-concurrent = 10
-interval = 1
-retry = 5
-
-[manager]
-api_base = "{{&managerUrl}}"
-token = ""
-ca_cert = ""
-
-[cgroup]
-enable = false
-
-[server]
-hostname = "$HOSTNAME"
-listen_addr = "0.0.0.0"
-listen_port = {{port}}
-ssl_cert = ""
-ssl_key = ""
-
-{{#mirrors}}
-[[mirrors]]
-name = "{{&name}}"
-{{#interval}}
-interval = {{interval}}
-{{/interval}}
-{{#retry}}
-retry = {{retry}}
-{{/retry}}
-provider = "{{&provider}}"
-upstream = "{{&upstream}}"
-{{#stage1_profile}}
-stage1_profile = "{{&stage1_profile}}"
-{{/stage1_profile}}
-{{#command}}
-command = "{{&command}}"
-{{/command}}
-{{#envs.length}}
-        [mirrors.env]
-        {{#envs}}
-        {{&.}}
-        {{/envs}}
-{{/envs.length}}
-{{#rsync_options.length}}
-rsync_options = [ {{&rsync_options}} ]
-{{/rsync_options.length}}
-{{/mirrors}}
-EOF
+aws s3 cp {{&tunasyncWorkerConf}} /etc/tunasync/worker.conf
+sed -i "s|++HOSTNAME++|$HOSTNAME|g" /etc/tunasync/worker.conf
+sed -i "s|++MANAGERURL++|$MANAGERURL|g" /etc/tunasync/worker.conf
 
 # create tunasync service
 cat > /usr/lib/systemd/system/tunasync.service << EOF
@@ -137,64 +88,7 @@ systemctl start tunasync.service
 
 # configure conf json of CloudWatch agent
 mkdir -p /opt/aws/amazon-cloudwatch-agent/etc/
-cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json << EOF
-{
-"metrics": {
-        "namespace": "{{&namespace}}",
-        "append_dimensions": {
-        "ImageId": "\${aws:ImageId}",
-        "InstanceId": "\${aws:InstanceId}",
-        "InstanceType": "\${aws:InstanceType}",
-        "{{&dimensionName}}": "\${aws:AutoScalingGroupName}"
-        },
-        "aggregation_dimensions" : [["{{&dimensionName}}"]],
-        "metrics_collected": {
-        "procstat": [
-                {
-                "exe": "tunasync",
-                "measurement": [
-                        "pid_count"
-                ]
-                }
-        ]
-        }
-},
-"logs": {
-        "logs_collected": {
-        "files": {
-                "collect_list": [
-                {
-                        "file_path": "/var/log/tunasync.log",
-                        "log_group_name": "{{&logPrefix}}/worker",
-                        "log_stream_name": "{instance_id}_{hostname}",
-                        "timestamp_format": "%H: %M: %S%y%b%-d",
-                        "timezone": "UTC"
-                }
-                {{#mirrors}}
-                ,
-                {
-                        "file_path": "{{&repoRoot}}/log/{{&name}}/{{&name}}_**",
-                        "log_group_name": "{{&logPrefix}}/mirrors/{{&name}}",
-                        "log_stream_name": "{instance_id}_{hostname}",
-                        {{#timeFormat}}
-                        "timestamp_format": "{{&timeFormat}}",
-                        {{/timeFormat}}
-                        {{^timeFormat}}
-                        "timestamp_format": "%H: %M: %S%y%b%-d",
-                        {{/timeFormat}}
-                        {{#logStartPattern}}
-                        "multi_line_start_pattern": "{{&logStartPattern}}",
-                        {{/logStartPattern}}
-                        "timezone": "UTC"
-                }
-                {{/mirrors}}
-                ]
-        }
-        },
-        "log_stream_name": "open-mirror-default-stream-name"
-}
-}
-EOF
+aws s3 cp {{&cloudwatchAgentConf}} /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 
 # start cloudwatch agent
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s &

--- a/package-lock.json
+++ b/package-lock.json
@@ -556,6 +556,20 @@
         "constructs": "^3.0.2"
       }
     },
+    "@aws-cdk/aws-s3-deployment": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-deployment/-/aws-s3-deployment-1.54.0.tgz",
+      "integrity": "sha512-wqgUdtvO2PzXIRyiKidhOGu6D7ONe4KlcbLg9qq5BS22Xgp3iMEtg6InBni4f5y3DNhEA7uJUvQnT/oDh4WZuA==",
+      "requires": {
+        "@aws-cdk/aws-cloudfront": "1.54.0",
+        "@aws-cdk/aws-iam": "1.54.0",
+        "@aws-cdk/aws-lambda": "1.54.0",
+        "@aws-cdk/aws-s3": "1.54.0",
+        "@aws-cdk/aws-s3-assets": "1.54.0",
+        "@aws-cdk/core": "1.54.0",
+        "constructs": "^3.0.2"
+      }
+    },
     "@aws-cdk/aws-sam": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sam/-/aws-sam-1.54.0.tgz",
@@ -2358,7 +2372,8 @@
             "esprima": "^4.0.1",
             "estraverse": "^4.2.0",
             "esutils": "^2.0.2",
-            "optionator": "^0.8.1"
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
             "esprima": {
@@ -2701,6 +2716,7 @@
           "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
           "dev": true,
           "requires": {
+            "graceful-fs": "^4.1.6",
             "universalify": "^1.0.0"
           }
         },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@aws-cdk/aws-ecs": "^1.54.0",
     "@aws-cdk/aws-ecs-patterns": "^1.54.0",
     "@aws-cdk/aws-efs": "^1.54.0",
+    "@aws-cdk/aws-s3-deployment": "^1.54.0",
     "@aws-cdk/core": "1.54.0",
     "mustache": "^4.0.1",
     "source-map-support": "^0.5.16"

--- a/test/opentuna.test.ts
+++ b/test/opentuna.test.ts
@@ -5,6 +5,7 @@ import * as mock from './vpc-mock';
 import ec2 = require('@aws-cdk/aws-ec2');
 import sns = require('@aws-cdk/aws-sns');
 import '@aws-cdk/assert/jest';
+import { ResourcePart } from '@aws-cdk/assert/lib/assertions/have-resource';
 
 describe('Tuna Manager stack', () => {
   let app: cdk.App;
@@ -167,4 +168,19 @@ describe('Tuna Manager stack', () => {
     });
   });
 
+  test('Asset bucket created', () => {
+    cdk.Tag.add(app, 'app', `OpenTuna`);
+    expect(stack).toHaveResourceLike('AWS::S3::Bucket', {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "app",
+            "Value": "OpenTuna"
+          }
+        ]
+      },
+      "UpdateReplacePolicy": "Delete",
+      "DeletionPolicy": "Delete",
+    }, ResourcePart.CompleteDefinition);
+  });
 });

--- a/test/tuna-worker.test.ts
+++ b/test/tuna-worker.test.ts
@@ -3,8 +3,13 @@ import * as cxapi from '@aws-cdk/cx-api';
 import * as Tuna from '../lib/tuna-worker';
 import * as mock from './vpc-mock';
 import ec2 = require('@aws-cdk/aws-ec2');
+import fs = require('fs');
+import path = require('path');
+import s3 = require('@aws-cdk/aws-s3');
 import sns = require('@aws-cdk/aws-sns');
 import '@aws-cdk/assert/jest';
+import { ResourcePart } from '@aws-cdk/assert/lib/assertions/have-resource';
+import { assert } from 'console';
 
 describe('Tunasync worker stack', () => {
   let app: cdk.App;
@@ -93,6 +98,7 @@ describe('Tunasync worker stack', () => {
     const vpc = ec2.Vpc.fromLookup(parentStack, `VPC`, {
       vpcId,
     });
+    const bucket = new s3.Bucket(parentStack, 'AssetBucket');
 
     const tunaWorkerSG = new ec2.SecurityGroup(parentStack, "TunaWorkerSG", {
       vpc,
@@ -106,42 +112,72 @@ describe('Tunasync worker stack', () => {
       notifyTopic: topic,
       managerUrl: 'http://tunasync-manager:80',
       tunaWorkerSG,
+      assetBucket: bucket,
     });
   });
 
   test('Tunasync worker auto scaling group created', () => {
     expect(stack).toHaveResourceLike('AWS::AutoScaling::AutoScalingGroup', {
-      "MaxSize": "1",
-      "MinSize": "1",
-      "Cooldown": "30",
-      "HealthCheckGracePeriod": 180,
-      "HealthCheckType": "EC2",
-      "NotificationConfigurations": [
-        {
-          "NotificationTypes": [
-            "autoscaling:EC2_INSTANCE_LAUNCH",
-            "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
-            "autoscaling:EC2_INSTANCE_TERMINATE",
-            "autoscaling:EC2_INSTANCE_TERMINATE_ERROR"
-          ],
-          "TopicARN": {
-            "Ref": "referencetoParentStackTestTopicCEBA4F88Ref"
+      "Properties":{
+        "MaxSize": "1",
+        "MinSize": "1",
+        "Cooldown": "30",
+        "HealthCheckGracePeriod": 180,
+        "HealthCheckType": "EC2",
+        "NotificationConfigurations": [
+          {
+            "NotificationTypes": [
+              "autoscaling:EC2_INSTANCE_LAUNCH",
+              "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+              "autoscaling:EC2_INSTANCE_TERMINATE",
+              "autoscaling:EC2_INSTANCE_TERMINATE_ERROR"
+            ],
+            "TopicARN": {
+              "Ref": "referencetoParentStackTestTopicCEBA4F88Ref"
+            }
           }
-        }
+        ],
+        "Tags": [
+          {
+            "Key": "component",
+            "PropagateAtLaunch": true,
+            "Value": "TunaWorker"
+          },
+          {
+            "Key": "Name",
+            "PropagateAtLaunch": true,
+            "Value": "ParentStack/TunaWorkerStack/TunaWorkerASG"
+          }
+        ],
+      },
+      "DependsOn": [
+        "WorkerConfFileDeploymentsCustomResource426C58D0"
       ],
-      "Tags": [
-        {
-          "Key": "component",
-          "PropagateAtLaunch": true,
-          "Value": "TunaWorker"
-        },
-        {
-          "Key": "Name",
-          "PropagateAtLaunch": true,
-          "Value": "ParentStack/TunaWorkerStack/TunaWorkerASG"
-        }
-      ],
+    }, ResourcePart.CompleteDefinition);
+  });
+
+  test('Config files deployment', () => {
+    expect(stack).toHaveResourceLike('Custom::CDKBucketDeployment', {
+      "DestinationBucketName": {
+        "Ref": "referencetoParentStackAssetBucket9670BCE7Ref"
+      },
+      "DestinationBucketKeyPrefix": "tunasync/worker/",
+      "RetainOnDelete": false,
+      "Prune": false
     });
+    // verify tuna-worker.conf
+    const confFilePath = path.join(__dirname, `../cdk.out/tuna-worker-conf-files`);
+    const tunaWorkers = fs.readdirSync(confFilePath, { withFileTypes: true, }).filter( (file: fs.Dirent) => file.name.match(/tuna-worker-.*\.conf/gi));
+    expect(tunaWorkers).toHaveLength(1);
+    const tunaWorkerConf = fs.readFileSync(`${confFilePath}/${tunaWorkers[0].name}`, 'utf-8');
+    expect(tunaWorkerConf).toContain('log_dir = "/mnt/efs/opentuna/log/{{.Name}}"');
+    expect(tunaWorkerConf).toContain('api_base = "++MANAGERURL++"');
+    expect(tunaWorkerConf).toContain('hostname = "++HOSTNAME++"');
+
+    const cloudwatchAgents = fs.readdirSync(confFilePath, { withFileTypes: true, }).filter( (file: fs.Dirent) => file.name.match(/amazon-cloudwatch-agent-.*\.conf/gi));
+    expect(cloudwatchAgents).toHaveLength(1);
+    const cloudwatchAgentConf = fs.readFileSync(`${confFilePath}/${cloudwatchAgents[0].name}`, 'utf-8');
+    expect(cloudwatchAgentConf).toContain(' "ImageId": "${aws:ImageId}",');
   });
 
   test('Tunasync worker launch configuration', () => {
@@ -160,7 +196,22 @@ describe('Tunasync worker stack', () => {
         }
       ],
       "UserData": {
-        "Fn::Base64": "Content-Type: multipart/mixed; boundary=\"//\"\nMIME-Version: 1.0\n\n--//\nContent-Type: text/cloud-config; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"cloud-config.txt\"\n\n#cloud-config\nrepo_update: true\nrepo_upgrade: all\npackages:\n - nfs-utils\n - amazon-efs-utils\n - python3-pip\n - git\n\n# run commands\nruncmd:\n - file_system_id_1=fs-012345\n - efs_mount_point_1=/mnt/efs/opentuna\n - mkdir -p \"${efs_mount_point_1}\"\n - test -f \"/sbin/mount.efs\" && echo \"${file_system_id_1}:/ ${efs_mount_point_1} efs tls,_netdev\" >> /etc/fstab || echo \"${file_system_id_1}.efs.cn-north-1.amazonaws.com.cn:/ ${efs_mount_point_1} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev 0 0\" >> /etc/fstab\n - test -f \"/sbin/mount.efs\" && echo -e \"\\n[client-info]\\nsource=liw\" >> /etc/amazon/efs/efs-utils.conf\n - mount -a -t efs,nfs4 defaults\n - tunaversion=v0.6.6\n - tunafile=\"${efs_mount_point_1}/tunasync/install/tunasync-linux-bin-${tunaversion}.tar.bz2\"\n - (test -f ${tunafile} && tar -xf ${tunafile} -C /usr/local/bin/) || (wget -c https://github.com/tuna/tunasync/releases/download/${tunaversion}/tunasync-linux-bin.tar.bz2 -O - | tar xjf -  -C /usr/local/bin/)\n - export PIP_DEFAULT_TIMEOUT=20; pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple 'bandersnatch<4.0' || pip3 install -i https://pypi.douban.com/simple 'bandersnatch<4.0'\n - tunascript_bin=\"${efs_mount_point_1}/tunasync/install/tunasync-scripts.tar.gz\"\n - tunascriptpath=/tunasync-scripts\n - mkdir -p ${tunascriptpath}\n - (test -f ${tunascript_bin} && tar -xf ${tunascript_bin} -C ${tunascriptpath}) || (git clone https://github.com/tuna/tunasync-scripts.git ${tunascriptpath})\n - rpm -i https://s3.cn-north-1.amazonaws.com.cn/amazoncloudwatch-agent-cn-north-1/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm\n\ncloud_final_modules:\n- [scripts-user, always]\n--//\nContent-Type: text/x-shellscript; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"userdata.txt\"\n\n#!/bin/bash -xe\nHOSTNAME=`hostname`\nREPO_ROOT=/mnt/efs/opentuna\nTUNASCRIPT_PATH=/tunasync-scripts\nmkdir -p /etc/tunasync/\n\n# create tunasync work config\ncat > /etc/tunasync/worker.conf << EOF\n[global]\nname = \"tunasync-worker\"\nlog_dir = \"${REPO_ROOT}/log/{{.Name}}\"\nmirror_dir = \"${REPO_ROOT}/data/\"\nconcurrent = 10\ninterval = 1\nretry = 5\n\n[manager]\napi_base = \"http://tunasync-manager:80\"\ntoken = \"\"\nca_cert = \"\"\n\n[cgroup]\nenable = false\n\n[server]\nhostname = \"$HOSTNAME\"\nlisten_addr = \"0.0.0.0\"\nlisten_port = 80\nssl_cert = \"\"\nssl_key = \"\"\n\n[[mirrors]]\nname = \"elrepo\"\ninterval = 720\nretry = 10\nprovider = \"rsync\"\nupstream = \"rsync://ftp.yz.yamagata-u.ac.jp/pub/linux/RPMS/elrepo/\"\n[[mirrors]]\nname = \"pypi\"\ninterval = 5\nprovider = \"command\"\nupstream = \"https://pypi.python.org/\"\ncommand = \"$TUNASCRIPT_PATH/pypi.sh\"\n        [mirrors.env]\n        INIT = \"0\"\nEOF\n\n# create tunasync service\ncat > /usr/lib/systemd/system/tunasync.service << EOF\n[Unit]\nDescription=Tunasync Worker daemon\n\n[Service]\nExecStart=/usr/local/bin/tunasync worker -config /etc/tunasync/worker.conf\nExecReload=/bin/kill -HUP \\$MAINPID\nType=simple\nKillMode=control-group\nRestart=on-failure\nRestartSec=20s\nStandardOutput=syslog\nStandardError=syslog\nSyslogIdentifier=tunasync\n\n[Install]\nWantedBy=multi-user.target\nEOF\n\ncat > /etc/rsyslog.d/tunasync.conf << EOF\nif \\$programname == 'tunasync' then /var/log/tunasync.log\n& stop\nEOF\n\n# start tunasync service\nsystemctl daemon-reload\nsystemctl restart rsyslog\nsystemctl enable tunasync.service\nsystemctl start tunasync.service\n\n# configure conf json of CloudWatch agent\nmkdir -p /opt/aws/amazon-cloudwatch-agent/etc/\ncat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json << EOF\n{\n\"metrics\": {\n        \"namespace\": \"OpenTuna\",\n        \"append_dimensions\": {\n        \"ImageId\": \"\\${aws:ImageId}\",\n        \"InstanceId\": \"\\${aws:InstanceId}\",\n        \"InstanceType\": \"\\${aws:InstanceType}\",\n        \"AutoScalingGroupName\": \"\\${aws:AutoScalingGroupName}\"\n        },\n        \"aggregation_dimensions\" : [[\"AutoScalingGroupName\"]],\n        \"metrics_collected\": {\n        \"procstat\": [\n                {\n                \"exe\": \"tunasync\",\n                \"measurement\": [\n                        \"pid_count\"\n                ]\n                }\n        ]\n        }\n},\n\"logs\": {\n        \"logs_collected\": {\n        \"files\": {\n                \"collect_list\": [\n                {\n                        \"file_path\": \"/var/log/tunasync.log\",\n                        \"log_group_name\": \"/opentuna/testing/tunasync/worker\",\n                        \"log_stream_name\": \"{instance_id}_{hostname}\",\n                        \"timestamp_format\": \"%H: %M: %S%y%b%-d\",\n                        \"timezone\": \"UTC\"\n                }\n                ,\n                {\n                        \"file_path\": \"/mnt/efs/opentuna/log/elrepo/elrepo_**\",\n                        \"log_group_name\": \"/opentuna/testing/tunasync/mirrors/elrepo\",\n                        \"log_stream_name\": \"{instance_id}_{hostname}\",\n                        \"timestamp_format\": \"%H: %M: %S%y%b%-d\",\n                        \"timezone\": \"UTC\"\n                }\n                ,\n                {\n                        \"file_path\": \"/mnt/efs/opentuna/log/pypi/pypi_**\",\n                        \"log_group_name\": \"/opentuna/testing/tunasync/mirrors/pypi\",\n                        \"log_stream_name\": \"{instance_id}_{hostname}\",\n                        \"timestamp_format\": \"%Y-%m-%d %H:%M:%S\",\n                        \"multi_line_start_pattern\": \"^\\\\\\\\d{4}-\\\\\\\\d{2}-\\\\\\\\d{2}\\\\\\\\s\\\\\\\\d{2}:\\\\\\\\d{2}:\\\\\\\\d{2},\\\\\\\\d{3}\",\n                        \"timezone\": \"UTC\"\n                }\n                ]\n        }\n        },\n        \"log_stream_name\": \"open-mirror-default-stream-name\"\n}\n}\nEOF\n\n# start cloudwatch agent\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s &\n--//"
+        "Fn::Base64": {
+          "Fn::Join": [
+            "",
+            [
+              "Content-Type: multipart/mixed; boundary=\"//\"\nMIME-Version: 1.0\n\n--//\nContent-Type: text/cloud-config; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"cloud-config.txt\"\n\n#cloud-config\nrepo_update: true\nrepo_upgrade: all\npackages:\n - nfs-utils\n - amazon-efs-utils\n - python3-pip\n - git\n - awscli\n\n# run commands\nruncmd:\n - file_system_id_1=fs-012345\n - efs_mount_point_1=/mnt/efs/opentuna\n - mkdir -p \"${efs_mount_point_1}\"\n - test -f \"/sbin/mount.efs\" && echo \"${file_system_id_1}:/ ${efs_mount_point_1} efs tls,_netdev\" >> /etc/fstab || echo \"${file_system_id_1}.efs.cn-north-1.amazonaws.com.cn:/ ${efs_mount_point_1} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev 0 0\" >> /etc/fstab\n - test -f \"/sbin/mount.efs\" && echo -e \"\\n[client-info]\\nsource=liw\" >> /etc/amazon/efs/efs-utils.conf\n - mount -a -t efs,nfs4 defaults\n - tunaversion=v0.6.6\n - tunafile=\"${efs_mount_point_1}/tunasync/install/tunasync-linux-bin-${tunaversion}.tar.bz2\"\n - (test -f ${tunafile} && tar -xf ${tunafile} -C /usr/local/bin/) || (wget -c https://github.com/tuna/tunasync/releases/download/${tunaversion}/tunasync-linux-bin.tar.bz2 -O - | tar xjf -  -C /usr/local/bin/)\n - export PIP_DEFAULT_TIMEOUT=20; pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple 'bandersnatch<4.0' || pip3 install -i https://pypi.douban.com/simple 'bandersnatch<4.0'\n - tunascript_bin=\"${efs_mount_point_1}/tunasync/install/tunasync-scripts.tar.gz\"\n - tunascriptpath=/tunasync-scripts\n - mkdir -p ${tunascriptpath}\n - (test -f ${tunascript_bin} && tar -xf ${tunascript_bin} -C ${tunascriptpath}) || (git clone https://github.com/tuna/tunasync-scripts.git ${tunascriptpath})\n - rpm -i https://s3.cn-north-1.amazonaws.com.cn/amazoncloudwatch-agent-cn-north-1/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm\n\ncloud_final_modules:\n- [scripts-user, always]\n--//\nContent-Type: text/x-shellscript; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"userdata.txt\"\n\n#!/bin/bash -xe\nHOSTNAME=`hostname`\nMANAGERURL=\"http://tunasync-manager:80\"\nmkdir -p /etc/tunasync/\n\nexport AWS_DEFAULT_REGION=cn-north-1\n\n# create tunasync work config\naws s3 cp s3://",
+              {
+                "Ref": "referencetoParentStackAssetBucket9670BCE7Ref"
+              },
+              "/tunasync/worker/tuna-worker-2a7a32b57c7f2feaf0044766dfebcc17.conf /etc/tunasync/worker.conf\nsed -i \"s|++HOSTNAME++|$HOSTNAME|g\" /etc/tunasync/worker.conf\nsed -i \"s|++MANAGERURL++|$MANAGERURL|g\" /etc/tunasync/worker.conf\n\n# create tunasync service\ncat > /usr/lib/systemd/system/tunasync.service << EOF\n[Unit]\nDescription=Tunasync Worker daemon\n\n[Service]\nExecStart=/usr/local/bin/tunasync worker -config /etc/tunasync/worker.conf\nExecReload=/bin/kill -HUP \\$MAINPID\nType=simple\nKillMode=control-group\nRestart=on-failure\nRestartSec=20s\nStandardOutput=syslog\nStandardError=syslog\nSyslogIdentifier=tunasync\n\n[Install]\nWantedBy=multi-user.target\nEOF\n\ncat > /etc/rsyslog.d/tunasync.conf << EOF\nif \\$programname == 'tunasync' then /var/log/tunasync.log\n& stop\nEOF\n\n# start tunasync service\nsystemctl daemon-reload\nsystemctl restart rsyslog\nsystemctl enable tunasync.service\nsystemctl start tunasync.service\n\n# configure conf json of CloudWatch agent\nmkdir -p /opt/aws/amazon-cloudwatch-agent/etc/\naws s3 cp s3://",
+              {
+                "Ref": "referencetoParentStackAssetBucket9670BCE7Ref"
+              },
+              "/tunasync/worker/amazon-cloudwatch-agent-b0f6a145d6ac64abbc08396a57bd3036.conf /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json\n\n# start cloudwatch agent\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s &\n--//"
+            ]
+          ]
+        }
       }
     });
   });


### PR DESCRIPTION
fix #29 

- [x] create an asset bucket in open tuna stack
- [x] deploy tunasync-worker conf and cloudwatch agent conf to s3
- [x] update user data of tunasync worker to fetch conf files from s3, check the user data size when synthesizing
- [x] unit tests
- [x] update readme