### PR TITLE
Allow http access to debian

### DIFF
--- a/lib/opentuna-stack.ts
+++ b/lib/opentuna-stack.ts
@@ -232,9 +232,9 @@ export class OpentunaStack extends cdk.Stack {
     });
 
     let commonBehaviorConfig = {
-      // special handling for HTTPS forwarding
+      // special handling for redirections
       forwardedValues: {
-        headers: ['Host', 'CloudFront-Forwarded-Proto'],
+        headers: ['Host'],
         queryString: true,
       },
     };
@@ -248,6 +248,7 @@ export class OpentunaStack extends cdk.Stack {
       originConfigs: [{
         customOriginSource: {
           domainName: useHTTPS ? `${stack.region}.${domainName}` : externalALB.loadBalancerDnsName,
+          originProtocolPolicy: cloudfront.OriginProtocolPolicy.MATCH_VIEWER
         },
         behaviors: [{
           ...commonBehaviorConfig,
@@ -301,7 +302,7 @@ export class OpentunaStack extends cdk.Stack {
       // when https is enabled
       cloudfrontProps = {
         httpVersion: cloudfront.HttpVersion.HTTP2,
-        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.ALLOW_ALL,
         ...cloudfrontProps
       };
 

--- a/lib/opentuna-stack.ts
+++ b/lib/opentuna-stack.ts
@@ -152,9 +152,10 @@ export class OpentunaStack extends cdk.Stack {
       certificates: cert ? [cert] : undefined,
       sslPolicy: useHTTPS ? elbv2.SslPolicy.RECOMMENDED : undefined,
     });
+    let httpOnlyALBListener: elbv2.ApplicationListener | undefined;
     if (useHTTPS) {
       // redirect HTTP to HTTPS
-      externalALB.addListener(`DefaultPort-80`, {
+      httpOnlyALBListener = externalALB.addListener(`DefaultPort-80`, {
         protocol: elbv2.ApplicationProtocol.HTTP,
         port: 80,
         open: true,
@@ -208,6 +209,7 @@ export class OpentunaStack extends cdk.Stack {
       notifyTopic: props.notifyTopic,
       ecsCluster,
       listener: defaultALBListener,
+      httpOnlyListener: httpOnlyALBListener,
       dashboard,
     });
 

--- a/lib/web-portal.ts
+++ b/lib/web-portal.ts
@@ -113,20 +113,6 @@ export class WebPortalStack extends cdk.NestedStack {
                 "/static/status/isoinfo.json",
             ])],
         })
-        // special handling for https
-        props.externalALBListener.addAction(`${usage}RedirectHTTPSAction`, {
-            action: elbv2.ListenerAction.redirect({
-                protocol: "HTTPS",
-                path: "/jobs",
-                port: "443",
-            }),
-            priority: 4,
-            conditions: [elbv2.ListenerCondition.pathPatterns([
-                "/static/tunasync.json",
-            ]), elbv2.ListenerCondition.httpHeader("CloudFront-Forwarded-Proto", [
-                "HTTPS"
-            ])],
-        })
 
         // route /jobs to tuna manager
         // there is no easy way to do this yet

--- a/test/opentuna.test.ts
+++ b/test/opentuna.test.ts
@@ -428,6 +428,29 @@ describe('Tuna Manager stack', () => {
       ],
       "SslPolicy": "ELBSecurityPolicy-2016-08"
     });
+
+    expect(stack).toHaveResource('AWS::ElasticLoadBalancingV2::ListenerRule', {
+      "Actions": [
+        {
+          "TargetGroupArn": {
+            "Ref": "ExternalALBDefaultPort80ContentServerGroup4C4C350F"
+          },
+          "Type": "forward"
+        }
+      ],
+      "Conditions": [
+        {
+          "Field": "path-pattern",
+          "Values": [
+            "/debian/*"
+          ]
+        }
+      ],
+      "ListenerArn": {
+        "Ref": "ExternalALBDefaultPort806952D605"
+      },
+      "Priority": 10
+    });
   });
 
   test('public access alb is expected', () => {
@@ -592,7 +615,7 @@ describe('Tuna Manager stack', () => {
               "HEAD"
             ],
             "Compress": true,
-              "DefaultTTL": 3600,
+            "DefaultTTL": 3600,
             "ForwardedValues": {
               "Cookies": {
                 "Forward": "none"

--- a/test/opentuna.test.ts
+++ b/test/opentuna.test.ts
@@ -576,13 +576,12 @@ describe('Tuna Manager stack', () => {
             "ForwardedValues": {
               "Headers": [
                 "Host",
-                "CloudFront-Forwarded-Proto"
               ],
               "QueryString": true
             },
             "PathPattern": "/jobs",
             "TargetOriginId": "origin1",
-            "ViewerProtocolPolicy": "redirect-to-https"
+            "ViewerProtocolPolicy": "allow-all"
           },
           {
             "AllowedMethods": [
@@ -603,7 +602,7 @@ describe('Tuna Manager stack', () => {
             },
             "PathPattern": "/rubygems/gems/*",
             "TargetOriginId": "origin2",
-            "ViewerProtocolPolicy": "redirect-to-https"
+            "ViewerProtocolPolicy": "allow-all"
           },
           {
             "AllowedMethods": [
@@ -624,7 +623,7 @@ describe('Tuna Manager stack', () => {
             },
             "PathPattern": "/rubygems/*",
             "TargetOriginId": "origin2",
-            "ViewerProtocolPolicy": "redirect-to-https"
+            "ViewerProtocolPolicy": "allow-all"
           }
         ],
         "Origins": [
@@ -635,7 +634,7 @@ describe('Tuna Manager stack', () => {
               "HTTPPort": 80,
               "HTTPSPort": 443,
               "OriginKeepaliveTimeout": 5,
-              "OriginProtocolPolicy": "https-only",
+              "OriginProtocolPolicy": "match-viewer",
               "OriginReadTimeout": 30,
               "OriginSSLProtocols": [
                 "TLSv1.2"


### PR DESCRIPTION
Problem statement:

By default, debian users don't have `apt-transport-https` and `ca-certificate` installed, thus can't use our mirror at the beginning.

Original HTTPS policy:

1. CloudFront forces redirect HTTP to HTTPS, and access ALB by HTTPS
2. ALB forces redirect HTTP to HTTPS as well, and handle CloudFront-Forwarded-Proto to give correct redirection result for /static/tunasync.json

Proposed HTTPS policy:

1. CloudFront forwards to ALB matching viewer protocol i.e. http://example.com -> http://region.example.com and https://example.com -> https://region.example.com
2. ALB forces redirect HTTP to HTTPS by default, but proxy `/debian/*` paths to content server
3. The rest part remains same
4. The special handling of CloudFront-Forwarded-Proto can be removed

Expected result:

1. Access to HTTP should be redirected to HTTPS except `/debian/*`
2. The rest functionality should work

Side effect:

1. Rubygems can be access by HTTP without redirecting to HTTPS (CloudFront supports separate viewer policy for each behavior, but CDK simplifies this and uses one policy for all)