### PR TITLE
feat: add cloudwatch agent to collect logs of tunasync manager

### DIFF
--- a/lib/opentuna-stack.ts
+++ b/lib/opentuna-stack.ts
@@ -182,6 +182,7 @@ export class OpentunaStack extends cdk.Stack {
       tunaManagerSG,
       tunaManagerALBSG,
       timeout: cdk.Duration.minutes(10),
+      assetBucket,
     });
 
     // Tunasync Worker stack

--- a/lib/tuna-manager-cloudwatch-agent.json
+++ b/lib/tuna-manager-cloudwatch-agent.json
@@ -1,0 +1,42 @@
+{
+        "metrics": {
+                "namespace": "{{&namespace}}",
+                "append_dimensions": {
+                        "ImageId": "${aws:ImageId}",
+                        "InstanceId": "${aws:InstanceId}",
+                        "InstanceType": "${aws:InstanceType}",
+                        "{{&dimensionName}}": "${aws:AutoScalingGroupName}"
+                },
+                "aggregation_dimensions": [
+                        [
+                                "{{&dimensionName}}"
+                        ]
+                ],
+                "metrics_collected": {
+                        "procstat": [
+                                {
+                                        "exe": "tunasync",
+                                        "measurement": [
+                                                "pid_count"
+                                        ]
+                                }
+                        ]
+                }
+        },
+        "logs": {
+                "logs_collected": {
+                        "files": {
+                                "collect_list": [
+                                        {
+                                                "file_path": "/var/log/tunasync.log",
+                                                "log_group_name": "{{&logPrefix}}/manager",
+                                                "log_stream_name": "{instance_id}_{hostname}",
+                                                "timestamp_format": "%H: %M: %S%y%b%-d",
+                                                "timezone": "UTC"
+                                        }
+                                ]
+                        }
+                },
+                "log_stream_name": "open-mirror-default-stream-name"
+        }
+}

--- a/lib/tuna-manager-user-data.txt
+++ b/lib/tuna-manager-user-data.txt
@@ -25,6 +25,7 @@ runcmd:
  - tunaversion=v0.6.7
  - tunafile="${efs_mount_point_1}/tunasync/install/tunasync-linux-amd64-bin-${tunaversion}.tar.gz"
  - (test -f ${tunafile} && tar -xf ${tunafile} -C /usr/local/bin/) || (wget -c https://github.com/tuna/tunasync/releases/download/${tunaversion}/tunasync-linux-amd64-bin.tar.gz -O - | tar xzf - -C /usr/local/bin/)
+ - rpm -i https://{{&s3RegionEndpoint}}/amazoncloudwatch-agent-{{&region}}/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
 
 cloud_final_modules:
 - [scripts-user, always]
@@ -36,6 +37,11 @@ Content-Disposition: attachment; filename="userdata.txt"
 
 #!/bin/bash -xe
 mkdir -p /etc/tunasync/
+mkdir -p /mnt/efs/opentuna/tunasync/
+
+export AWS_DEFAULT_REGION={{&region}}
+
+# setup tunasync manager config
 cat > /etc/tunasync/manager.conf << EOF
 debug = false
 
@@ -51,6 +57,42 @@ db_file = "/mnt/efs/opentuna/tunasync/manager.db"
 ca_cert = ""
 
 EOF
-mkdir -p /mnt/efs/opentuna/tunasync/
-tunasync manager -config /etc/tunasync/manager.conf &
+
+# create tunasync service
+cat > /usr/lib/systemd/system/tunasync.service << EOF
+[Unit]
+Description=Tunasync Manager daemon
+
+[Service]
+ExecStart=/usr/local/bin/tunasync manager -config /etc/tunasync/manager.conf
+ExecReload=/bin/kill -HUP \$MAINPID
+Type=simple
+KillMode=control-group
+Restart=on-failure
+RestartSec=20s
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=tunasync
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > /etc/rsyslog.d/tunasync.conf << EOF
+if \$programname == 'tunasync' then /var/log/tunasync.log
+& stop
+EOF
+
+# start tunasync service
+systemctl daemon-reload
+systemctl restart rsyslog
+systemctl enable tunasync.service
+systemctl start tunasync.service
+
+# configure conf json of CloudWatch agent
+mkdir -p /opt/aws/amazon-cloudwatch-agent/etc/
+aws s3 cp {{&cloudwatchAgentConf}} /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+# start cloudwatch agent
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s &
 --//

--- a/lib/tuna-worker.ts
+++ b/lib/tuna-worker.ts
@@ -11,8 +11,8 @@ import * as region_info from '@aws-cdk/region-info';
 import * as Mustache from 'mustache';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as crypto from 'crypto';
 import { getMirrorConfig } from './mirror-config';
+import { deleteFolderRecursive, md5Hash } from './utils';
 
 export interface TunaWorkerProps extends cdk.NestedStackProps {
     readonly vpc: ec2.IVpc;
@@ -166,23 +166,4 @@ export class TunaWorkerStack extends cdk.NestedStack {
 
         cdk.Tags.of(this).add('component', usage);
     }
-}
-
-var deleteFolderRecursive = function (path: fs.PathLike) {
-    if (fs.existsSync(path)) {
-        fs.readdirSync(path).forEach(function (file, index) {
-            var curPath = path + "/" + file;
-            if (fs.lstatSync(curPath).isDirectory()) { // recurse
-                deleteFolderRecursive(curPath);
-            } else { // delete file
-                fs.unlinkSync(curPath);
-            }
-        });
-        fs.rmdirSync(path);
-    }
-};
-
-
-var md5Hash = function (content: string) {
-    return crypto.createHash('md5').update(content).digest('hex');
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,21 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+
+export function deleteFolderRecursive (path: fs.PathLike) {
+    if (fs.existsSync(path)) {
+        fs.readdirSync(path).forEach(function (file, index) {
+            var curPath = path + "/" + file;
+            if (fs.lstatSync(curPath).isDirectory()) { // recurse
+                deleteFolderRecursive(curPath);
+            } else { // delete file
+                fs.unlinkSync(curPath);
+            }
+        });
+        fs.rmdirSync(path);
+    }
+};
+
+
+export function md5Hash(content: string) {
+    return crypto.createHash('md5').update(content).digest('hex');
+}

--- a/test/tuna-manager.test.ts
+++ b/test/tuna-manager.test.ts
@@ -1,9 +1,10 @@
 import * as cdk from '@aws-cdk/core';
 import * as cxapi from '@aws-cdk/cx-api';
+import * as s3 from '@aws-cdk/aws-s3';
+import * as ec2 from '@aws-cdk/aws-ec2';
+import * as sns from '@aws-cdk/aws-sns';
 import * as Tuna from '../lib/tuna-manager';
 import * as mock from './context-provider-mock';
-import ec2 = require('@aws-cdk/aws-ec2');
-import sns = require('@aws-cdk/aws-sns');
 import '@aws-cdk/assert/jest';
 
 describe('Tuna Manager stack', () => {
@@ -89,6 +90,7 @@ describe('Tuna Manager stack', () => {
     const vpc = ec2.Vpc.fromLookup(parentStack, `VPC`, {
       vpcId,
     });
+    const bucket = new s3.Bucket(parentStack, 'AssetBucket');
 
     const tunaManagerSG = new ec2.SecurityGroup(parentStack, "TunaManagerSG", {
       vpc,
@@ -107,6 +109,7 @@ describe('Tuna Manager stack', () => {
       notifyTopic: topic,
       tunaManagerSG,
       tunaManagerALBSG,
+      assetBucket: bucket,
     });
   });
 

--- a/test/tuna-manager.test.ts
+++ b/test/tuna-manager.test.ts
@@ -163,12 +163,23 @@ describe('Tuna Manager stack', () => {
         }
       ],
       "UserData": {
-        "Fn::Base64": "Content-Type: multipart/mixed; boundary=\"//\"\nMIME-Version: 1.0\n\n--//\nContent-Type: text/cloud-config; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"cloud-config.txt\"\n\n#cloud-config\nrepo_update: true\nrepo_upgrade: all\npackages:\n - nfs-utils\n - amazon-efs-utils\n\n# run commands\nruncmd:\n - file_system_id_1=fs-012345\n - efs_mount_point_1=/mnt/efs/opentuna\n - mkdir -p \"${efs_mount_point_1}\"\n - test -f \"/sbin/mount.efs\" && echo \"${file_system_id_1}:/ ${efs_mount_point_1} efs tls,_netdev\" >> /etc/fstab || echo \"${file_system_id_1}.efs.cn-north-1.amazonaws.com.cn:/ ${efs_mount_point_1} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev 0 0\" >> /etc/fstab\n - test -f \"/sbin/mount.efs\" && echo -e \"\\n[client-info]\\nsource=liw\" >> /etc/amazon/efs/efs-utils.conf\n - mount -a -t efs,nfs4 defaults\n - tunaversion=v0.6.7\n - tunafile=\"${efs_mount_point_1}/tunasync/install/tunasync-linux-amd64-bin-${tunaversion}.tar.gz\"\n - (test -f ${tunafile} && tar -xf ${tunafile} -C /usr/local/bin/) || (wget -c https://github.com/tuna/tunasync/releases/download/${tunaversion}/tunasync-linux-amd64-bin.tar.gz -O - | tar xzf - -C /usr/local/bin/)\n\ncloud_final_modules:\n- [scripts-user, always]\n--//\nContent-Type: text/x-shellscript; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"userdata.txt\"\n\n#!/bin/bash -xe\nmkdir -p /etc/tunasync/\ncat > /etc/tunasync/manager.conf << EOF\ndebug = false\n\n[server]\naddr = \"0.0.0.0\"\nport = 80\nssl_cert = \"\"\nssl_key = \"\"\n\n[files]\ndb_type = \"bolt\"\ndb_file = \"/mnt/efs/opentuna/tunasync/manager.db\"\nca_cert = \"\"\n\nEOF\nmkdir -p /mnt/efs/opentuna/tunasync/\ntunasync manager -config /etc/tunasync/manager.conf &\n--//"
+        "Fn::Base64": {
+          "Fn::Join": [
+            "",
+            [
+              "Content-Type: multipart/mixed; boundary=\"//\"\nMIME-Version: 1.0\n\n--//\nContent-Type: text/cloud-config; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"cloud-config.txt\"\n\n#cloud-config\nrepo_update: true\nrepo_upgrade: all\npackages:\n - nfs-utils\n - amazon-efs-utils\n\n# run commands\nruncmd:\n - file_system_id_1=fs-012345\n - efs_mount_point_1=/mnt/efs/opentuna\n - mkdir -p \"${efs_mount_point_1}\"\n - test -f \"/sbin/mount.efs\" && echo \"${file_system_id_1}:/ ${efs_mount_point_1} efs tls,_netdev\" >> /etc/fstab || echo \"${file_system_id_1}.efs.cn-north-1.amazonaws.com.cn:/ ${efs_mount_point_1} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev 0 0\" >> /etc/fstab\n - test -f \"/sbin/mount.efs\" && echo -e \"\\n[client-info]\\nsource=liw\" >> /etc/amazon/efs/efs-utils.conf\n - mount -a -t efs,nfs4 defaults\n - tunaversion=v0.6.7\n - tunafile=\"${efs_mount_point_1}/tunasync/install/tunasync-linux-amd64-bin-${tunaversion}.tar.gz\"\n - (test -f ${tunafile} && tar -xf ${tunafile} -C /usr/local/bin/) || (wget -c https://github.com/tuna/tunasync/releases/download/${tunaversion}/tunasync-linux-amd64-bin.tar.gz -O - | tar xzf - -C /usr/local/bin/)\n - rpm -i https://s3.cn-north-1.amazonaws.com.cn/amazoncloudwatch-agent-cn-north-1/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm\n\ncloud_final_modules:\n- [scripts-user, always]\n--//\nContent-Type: text/x-shellscript; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"userdata.txt\"\n\n#!/bin/bash -xe\nmkdir -p /etc/tunasync/\nmkdir -p /mnt/efs/opentuna/tunasync/\n\nexport AWS_DEFAULT_REGION=cn-north-1\n\n# setup tunasync manager config\ncat > /etc/tunasync/manager.conf << EOF\ndebug = false\n\n[server]\naddr = \"0.0.0.0\"\nport = 80\nssl_cert = \"\"\nssl_key = \"\"\n\n[files]\ndb_type = \"bolt\"\ndb_file = \"/mnt/efs/opentuna/tunasync/manager.db\"\nca_cert = \"\"\n\nEOF\n\n# create tunasync service\ncat > /usr/lib/systemd/system/tunasync.service << EOF\n[Unit]\nDescription=Tunasync Manager daemon\n\n[Service]\nExecStart=/usr/local/bin/tunasync manager -config /etc/tunasync/manager.conf\nExecReload=/bin/kill -HUP \\$MAINPID\nType=simple\nKillMode=control-group\nRestart=on-failure\nRestartSec=20s\nStandardOutput=syslog\nStandardError=syslog\nSyslogIdentifier=tunasync\n\n[Install]\nWantedBy=multi-user.target\nEOF\n\ncat > /etc/rsyslog.d/tunasync.conf << EOF\nif \\$programname == 'tunasync' then /var/log/tunasync.log\n& stop\nEOF\n\n# start tunasync service\nsystemctl daemon-reload\nsystemctl restart rsyslog\nsystemctl enable tunasync.service\nsystemctl start tunasync.service\n\n# configure conf json of CloudWatch agent\nmkdir -p /opt/aws/amazon-cloudwatch-agent/etc/\naws s3 cp s3://",
+              {
+                "Ref": "referencetoParentStackAssetBucket9670BCE7Ref"
+              },
+              "/tunasync/manager/amazon-cloudwatch-agent-34b742e9c3c72b528e3f180d0c20a7ad.conf /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json\n\n# start cloudwatch agent\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s &\n--//"
+            ]
+          ]
+        }
       }
     });
   });
 
-  test('Tuna manager running with IAM profile role having SSM managed policy', () => {
+  test('Tuna manager running with IAM profile role having SSM managed policy and cloudwatch agent', () => {
     expect(stack).toHaveResource('AWS::IAM::Role', {
       "AssumeRolePolicyDocument": {
         "Statement": [
@@ -192,6 +203,18 @@ describe('Tuna Manager stack', () => {
                 "Ref": "AWS::Partition"
               },
               ":iam::aws:policy/AmazonSSMManagedInstanceCore"
+            ]
+          ]
+        },
+        {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":iam::aws:policy/CloudWatchAgentServerPolicy"
             ]
           ]
         }


### PR DESCRIPTION
- [x] Add cloudwatch agent to tuna manager instance
- [x] Log tunasync manager output to /var/log/tunasync.log
- [x] Use systemd to manage tunasync manager

By the way, systemd will try to restart tunasync manager when it quits, and might help #37 