### PR TITLE
chore: bump ci nodejs to 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Nodejs 12 is EOL: https://nodejs.dev/en/about/releases/