### PR TITLE
chore: add dependabot for bumping submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
mirror-web and (deployed tunasync-scripts) are submodules of opentuna, however, they do not get bumped often.

This PR introduces the dependabot for git submodules, so that the upstream change can be timely integrated into opentuna.

Maybe @jiegec could add tunasync-scripts in this repo in another PR and ensure the version depolyed and the version in the repo are the same? possibly through CI. 