### PR TITLE
feat: redirect 404 help to generic help

### DIFF
--- a/web-portal/_config.yml
+++ b/web-portal/_config.yml
@@ -20,6 +20,11 @@ hide_navbar: true
 hide_server_status: true
 footnote: <img alt="wangan_icon" title="wangan_icon" src="//s3.cn-north-1.amazonaws.com.cn/aws-dam-prod/china/0089205973_1471847044_icon.888cd2e3d7db9c6704dffbf66a752793979f7bf2.png"> <a href="http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=11010802032579">京公网安备 11010802032579号</a> | <a href="https://beian.miit.gov.cn/">京ICP备20029420号-1</a>
 
+hide_mirrorz: false
+mirrorz_desc: 校园网联合镜像站
+mirrorz_link: "https://mirrors.cernet.edu.cn/list"
+mirrorz_help_link: "https://help.mirrors.cernet.edu.cn/"
+
 # Build settings
 highlighter: rouge
 markdown: kramdown


### PR DESCRIPTION
See https://github.com/tuna/issues/issues/1669#issuecomment-1515219226 and https://github.com/tuna/mirror-web/commit/d688f4c644f59eeb12c468727cfe129a7bebc253

More specifically, the new commit in mirror-web requires `hide_mirrorz` in _config.yml